### PR TITLE
Update PCC-Large QA config and fix torch autocast FutureWarning

### DIFF
--- a/PCC/script/eval/qa.sh
+++ b/PCC/script/eval/qa.sh
@@ -1,4 +1,6 @@
 export CUDA_VISIBLE_DEVICES=0
+
+#---------------PCC Lite Configuration---------------#
 COMPRESS_MODEL_PATH=Stage2-PCC-Lite-4x
 CONVERTER_MODEL_PATH=Stage2-PCC-Lite-4x
 LLM_MODEL_PATH=meta-llama/Meta-Llama-3-8B-Instruct
@@ -12,3 +14,22 @@ python -m experience.qa.evaluate_qa  \
     --compress_ratio ${COMPRESS_RATIO} \
     --write True \
     --segment_length 256
+
+
+#---------------PCC Large Configuration---------------#
+# COMPRESS_MODEL_PATH=PCC-Large-Encoder-Llama3-8B-Instruct
+# ADAPTER_MODEL_PATH=Stage2-PCC-Large-4x
+# CONVERTER_MODEL_PATH=Stage2-PCC-Large-4x
+# LLM_MODEL_PATH=meta-llama/Meta-Llama-3-8B-Instruct
+# COMPRESS_RATIO=4
+
+# python -m experience.qa.evaluate_qa  \
+#     --dataset nq \
+#     --use_lora True \
+#     --adapter_model ${ADAPTER_MODEL_PATH} \
+#     --compress_model_path ${COMPRESS_MODEL_PATH} \
+#     --converter_model_path ${CONVERTER_MODEL_PATH} \
+#     --decoder_model ${LLM_MODEL_PATH} \
+#     --compress_ratio ${COMPRESS_RATIO} \
+#     --write True \
+#     --segment_length 256


### PR DESCRIPTION
## What does this PR do?

This PR include the following updates:

---

### [6d0b684423e9f35fd8c4fa68828192d8aa09a999] Configuration update
- Provided usage instructions for PCC-Large QA launch script

---

### [869f80a2d63121f25b0743e3df095238b763bb3d] Deprecation Fix
- Replaced torch.cuda.amp.autocast with torch.amp.autocast('cuda', ...).
- Resolves the following FutureWarning:
> FutureWarning: torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cuda', args...) instead.
